### PR TITLE
Fix tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "@types/core-js": "^0.9.35",
     "marked": "^0.3.6",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,16 @@
   "compilerOptions": {
     "jsx": "react",
     "module": "es6",
+    "target": "es5",
+    "lib": [
+      "dom",
+      "es7"
+    ],
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "public/build",
-    "sourceMap": true,
-    "target": "es5"
+    "sourceMap": true
   },
   "exclude": [
     ".tscache",


### PR DESCRIPTION
# Why

TypeScriptのトランスパイル/tslintが落ちるようになったので修正

# What

直接的な原因は型定義のために使っていたpackageがアップデートされたこと
(@types/core-jsが0.9.35 => 0.9.37になった)

そもそもTypeScriptはtarget: "es5"にするとes5の型定義しか含めてくれない模様
(Promiseなどを使っている部分で型定義がないってエラーが出る)
というわけで、型定義のパッケージを利用していた

調べてみたら、tsconfigにlibというオプションがあって、
それに"es6" / "es7"を渡すと、きちんとes6/7で導入された機能も使えるような型定義が含まれるとのこと

なので、libに"es7"を指定して、core-jsはdependencesから削除した

REF: http://www.typescriptlang.org/docs/handbook/compiler-options.html