### PR TITLE
Change Mathjax options to force render inner texts of code and pre tags

### DIFF
--- a/app/views/contests/_import_mathjax.html.erb
+++ b/app/views/contests/_import_mathjax.html.erb
@@ -3,6 +3,7 @@
   MathJax.Hub.Config({
    tex2jax: {
      inlineMath: [ ['$','$'] ],
+     skipTags: ["script","noscript","style","textarea"],
      processEscapes: true
    }
   });

--- a/src/tutorial/ProblemStatementParseTest.tsx
+++ b/src/tutorial/ProblemStatementParseTest.tsx
@@ -7,6 +7,7 @@ export default class ProblemStatementParseTest extends React.Component<{}, {}> {
     return (
       <div>
         <MarkdownRenderer text='# This is a test header\n\nthis is a **test** *content*.' />
+        <MarkdownRenderer text='``normal pre``\n\n```\n$x_i \\leq y$\n$z_j ... w_j$\n```\n\n' />
         <MarkdownRenderer text='日本語もおｋ\n\n\n\n* One\n* Two\n* Three' />
         <MarkdownRenderer text=
         'Rendering mathmatical notations like $1 \\leq a_n, b_n \\leq 10^{5}$ is supported by using Mathjax.' />


### PR DESCRIPTION
MathJaxのレンダリングが，preタグ内やcodeタグ内はoffになっているが，問題分中ではpreタグ内でもmathjaxのレンダリングを行いたいので，MathJaxのオプションを変更しました．