### PR TITLE
update markdown-renderer not to render emphsize _XX_ for mathjax

### DIFF
--- a/src/contests/MarkdownRenderer.tsx
+++ b/src/contests/MarkdownRenderer.tsx
@@ -7,6 +7,16 @@ export interface Props {
 }
 
 export default class MarkdownRenderer extends React.Component<Props, {}> {
+  private renderer: MarkedRenderer;
+
+  constructor(props: Props) {
+    super(props);
+    this.renderer = new marked.Renderer();
+    this.renderer.em = (str: string) => {
+      return '_' + str + '_';
+    };
+  }
+
   public componentDidMount() {
     MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
   }
@@ -16,7 +26,7 @@ export default class MarkdownRenderer extends React.Component<Props, {}> {
   public render() {
     return (
       <div className='markdown-body'>
-        { renderHTML(marked(this.props.text)) }
+        { renderHTML(marked(this.props.text, { renderer: this.renderer })) }
       </div>
     );
   }


### PR DESCRIPTION
現状のmarkdown rendererだと，`_XXXX_`の形の強調部分をパースするが，これはMathJax(Tex)の`x_i, y_i`みたいな下付き文字と競合してしまう．
今回のシステムはMathJaxを優先し，markdownの強調を無理矢理取り消す処理を入れました