### PR TITLE
Add StudentID to Users table

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :student_id])
   end
 
   def staging_authentication

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable
 
+  validates :student_id, presence: true, length: { is: 8 }
+
   has_many :contest_registrations
   has_many :contests, through: :contest_registrations
   has_many :submissions

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -20,6 +20,14 @@
             </tr>
             <tr class="usersAuth--row">
               <td class="usersAuth--cell">
+                <%= f.label :student_id %>
+              </td>
+              <td class="usersAuth--cell">
+                <%= f.text_field :student_id, class: 'usersAuth--input' %>
+              </td>
+            </tr>
+            <tr class="usersAuth--row">
+              <td class="usersAuth--cell">
                 <%= f.label :email %>
               </td>
               <td class="usersAuth--cell">

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -4,6 +4,7 @@ ja:
       user:
         current_password: "現在のパスワード"
         name: "ユーザー名"
+        student_id: "学籍番号 (CDなし8桁) "
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "確認用パスワード"

--- a/db/migrate/20170515113707_add_student_id_to_users.rb
+++ b/db/migrate/20170515113707_add_student_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddStudentIdToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :student_id, :string, null: false, limit: 8, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170428165657) do
+ActiveRecord::Schema.define(version: 20170515113707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,12 +83,12 @@ ActiveRecord::Schema.define(version: 20170428165657) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                            default: "", null: false
+    t.string   "encrypted_password",               default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",                    default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -97,9 +97,10 @@ ActiveRecord::Schema.define(version: 20170428165657) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
     t.string   "name"
+    t.string   "student_id",             limit: 8, default: "", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :user do
     sequence(:name) { |n| "user #{n}" }
+    sequence(:student_id) { |n| "1W16#{format('%04d', n)}" }
     sequence(:email) { |n| "user-#{n}@example.com" }
     password 'password'
     confirmed_at 3.days.ago


### PR DESCRIPTION
Users テーブルに `student_id` カラムを追加し、学籍番号を入力できるようにします。

**メールアドレスから学籍番号を対応させる手段がないことがわかるまでマージしないでください。**