### PR TITLE
フォームの修正

### DIFF
--- a/app/views/admin/contests/_form.html.erb
+++ b/app/views/admin/contests/_form.html.erb
@@ -48,7 +48,7 @@
 
   <div class="field">
     <%= f.label :status %>
-    <%= f.check_box :status, checked_value: 1, unchecked_value: 0 %>
+    <%= f.select :status, Contest.statuses.keys %>
   </div>
 
   <div class="field">


### PR DESCRIPTION
enum使ってるとinteger型で流し込もうとするとエラーになるみたいなので、enumのkeyをセレクトで指定するようにした（チェックボタンよりこの方がわかりやすそう）