### PR TITLE
Change the e-mail address of the sender

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'exkazuu@nii.ac.jp'
+  config.mailer_sender = 'exkazuu@gmail.com'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'DeviseMailer'


### PR DESCRIPTION
exkazuu@nii.ac.jp はそのうち使えなくなるため。