### PR TITLE
dependabot: too noisy

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,13 @@ update_configs:
       - Shikugawa
       - musaprg
     target_branch: master
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"
   - package_manager: "ruby:bundler"
     directory: "/"
     update_schedule: "daily"
@@ -14,3 +21,10 @@ update_configs:
       - Shikugawa
       - musaprg
     target_branch: master
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"


### PR DESCRIPTION
Dependabotの通知でRecent Activityが汚れて不便なので、Development関係のモジュールは全部自動でマージして、それ以外はパッチアップデートのみ自動でアップデートするようにする。