### PR TITLE
Fix to use the API Key for SMTP authentication

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,8 +67,8 @@ Rails.application.configure do
     address: 'smtp.sendgrid.net',
     port: 587,
     domain: 'heroku.com',
-    user_name: ENV['SENDGRID_USERNAME'],
-    password: ENV['SENDGRID_PASSWORD'],
+    user_name: 'apikey',
+    password: ENV['SENDGRID_API_KEY'],
     authentication: 'plain',
     enable_starttls_auto: true
   }


### PR DESCRIPTION
fixes: #674 

SendGridの認証をAPIKeyを使ったものに変更しました